### PR TITLE
Try to load `libtiff` through other methods if `ctypes.util.find_library` fails completely.

### DIFF
--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -37,10 +37,18 @@ else:
         lib = '../Frameworks/libtiff.dylib'
     else:
         lib = ctypes.util.find_library('tiff')
-if lib is None:
-    raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
 
-libtiff = ctypes.cdll.LoadLibrary(lib)
+libtiff = None if lib is None else ctypes.cdll.LoadLibrary(lib)
+if libtiff is None:
+    try:
+        if sys.platform == "darwin":
+            libtiff = ctypes.cdll.LoadLibrary("libtiff.dylib")
+        elif "win" in sys.platform:
+            libtiff = ctypes.cdll.LoadLibrary("libtiff.dll")
+        else:
+            libtiff = ctypes.cdll.LoadLibrary("libtiff.so")
+    except OSError:
+        raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
 
 libtiff.TIFFGetVersion.restype = ctypes.c_char_p
 libtiff.TIFFGetVersion.argtypes = []

--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -21,34 +21,41 @@ import ctypes.util
 import struct
 import collections
 
-if os.name=='nt':
-    # assume that the directory of libtiff3.dll is in PATH.
-    lib = ctypes.util.find_library('libtiff3')
-    if lib is None:
-        # try default installation path:
-        lib = r'C:\Program Files\GnuWin32\bin\libtiff3.dll'
-        if os.path.isfile (lib):
-            print 'You should add %r to PATH environment variable and reboot.' % (os.path.dirname (lib))
-        else:
-            lib = None
-else:
-    if hasattr(sys, 'frozen') and sys.platform == 'darwin' and os.path.exists('../Frameworks/libtiff.dylib'):
-        # py2app support, see Issue 8.
-        lib = '../Frameworks/libtiff.dylib'
-    else:
-        lib = ctypes.util.find_library('tiff')
 
-libtiff = None if lib is None else ctypes.cdll.LoadLibrary(lib)
-if libtiff is None:
-    try:
-        if sys.platform == "darwin":
-            libtiff = ctypes.cdll.LoadLibrary("libtiff.dylib")
-        elif "win" in sys.platform:
-            libtiff = ctypes.cdll.LoadLibrary("libtiff.dll")
+cwd = os.getcwd()
+try:
+    os.chdir(os.path.dirname(__file__))
+
+    if os.name=='nt':
+        # assume that the directory of libtiff3.dll is in PATH.
+        lib = ctypes.util.find_library('libtiff3')
+        if lib is None:
+            # try default installation path:
+            lib = r'C:\Program Files\GnuWin32\bin\libtiff3.dll'
+            if os.path.isfile (lib):
+                print 'You should add %r to PATH environment variable and reboot.' % (os.path.dirname (lib))
+            else:
+                lib = None
+    else:
+        if hasattr(sys, 'frozen') and sys.platform == 'darwin' and os.path.exists('../Frameworks/libtiff.dylib'):
+            # py2app support, see Issue 8.
+            lib = '../Frameworks/libtiff.dylib'
         else:
-            libtiff = ctypes.cdll.LoadLibrary("libtiff.so")
-    except OSError:
-        raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
+            lib = ctypes.util.find_library('tiff')
+
+    libtiff = None if lib is None else ctypes.cdll.LoadLibrary(lib)
+    if libtiff is None:
+        try:
+            if sys.platform == "darwin":
+                libtiff = ctypes.cdll.LoadLibrary("libtiff.dylib")
+            elif "win" in sys.platform:
+                libtiff = ctypes.cdll.LoadLibrary("libtiff.dll")
+            else:
+                libtiff = ctypes.cdll.LoadLibrary("libtiff.so")
+        except OSError:
+            raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
+finally:
+    os.chdir(cwd)
 
 libtiff.TIFFGetVersion.restype = ctypes.c_char_p
 libtiff.TIFFGetVersion.argtypes = []


### PR DESCRIPTION
Fixes #35.

How this works:
- If `ctypes.util.find_library` fails to find the path, try to load the library with proper extension using `ctypes.cdll.LoadLibrary` and a guess at the full library name. This seems to work in some cases.
- To provide greater flexibility, we also make sure the package is on the search path by making it the current directory. This way if a bundled copy of `libtiff` comes with the library it can be found. Alternatively, if resolution is not working for someone they can link or copy the library into the package.

Probably needs some rewording of the `ImportError` message, as well.
