### PR TITLE
Small improvements on ctypes libtiff wrapper code

### DIFF
--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -121,7 +121,7 @@ name_to_define_map = dict(Orientation={}, Compression={},
 
 for name, value in d.items():
     if name.startswith ('_'): continue
-    exec '%s = %s' % (name, value)
+    globals()[name] = value
     for n in define_to_name_map:
         if name.startswith(n.upper()):
             define_to_name_map[n][value] = name        
@@ -245,7 +245,7 @@ def add_tags(tag_list):
     tag_list_array = (TIFFFieldInfo * len(tag_list))(*tag_list)
     for field_info in tag_list_array:
         name = "TIFFTAG_" + str(field_info.field_name).upper()
-        exec 'global %s; %s = %s' % (name, name, field_info.field_tag)
+        globals()[name] = field_info.field_tag
         if field_info.field_writecount > 1 and field_info.field_type != TIFFDataType.TIFF_ASCII:
             tifftags[field_info.field_tag] = (ttype2ctype[field_info.field_type]*field_info.field_writecount, lambda d:d.contents[:])
         else:

--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -510,7 +510,7 @@ class TIFF(ctypes.c_void_p):
         write_rgb: bool
           Write rgb image if data has 3 dimensions (otherwise, writes a multipage TIFF).
         """
-        COMPRESSION = self._fix_compression (compression)
+        compression = self._fix_compression (compression)
 
         arr = np.ascontiguousarray(arr)
         sample_format = None
@@ -538,7 +538,7 @@ class TIFF(ctypes.c_void_p):
             self.SetField(TIFFTAG_IMAGEWIDTH, width)
             self.SetField(TIFFTAG_IMAGELENGTH, 1)
             self.SetField(TIFFTAG_BITSPERSAMPLE, bits)
-            self.SetField(TIFFTAG_COMPRESSION, COMPRESSION)
+            self.SetField(TIFFTAG_COMPRESSION, compression)
             self.SetField(TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK)
             self.SetField(TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT)
             self.SetField(TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG)
@@ -554,7 +554,7 @@ class TIFF(ctypes.c_void_p):
             self.SetField(TIFFTAG_IMAGEWIDTH, width)
             self.SetField(TIFFTAG_IMAGELENGTH, height)
             self.SetField(TIFFTAG_BITSPERSAMPLE, bits)
-            self.SetField(TIFFTAG_COMPRESSION, COMPRESSION)
+            self.SetField(TIFFTAG_COMPRESSION, compression)
             #self.SetField(TIFFTAG_SAMPLESPERPIXEL, 1)
             self.SetField(TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK)
             self.SetField(TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT)
@@ -578,7 +578,7 @@ class TIFF(ctypes.c_void_p):
                     size = width * height * arr.itemsize
 
                 self.SetField(TIFFTAG_BITSPERSAMPLE, bits)
-                self.SetField(TIFFTAG_COMPRESSION, COMPRESSION)
+                self.SetField(TIFFTAG_COMPRESSION, compression)
                 self.SetField(TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB)
                 self.SetField(TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT)
                 self.SetField(TIFFTAG_IMAGEWIDTH, width)
@@ -608,7 +608,7 @@ class TIFF(ctypes.c_void_p):
                     self.SetField(TIFFTAG_IMAGEWIDTH, width)
                     self.SetField(TIFFTAG_IMAGELENGTH, height)
                     self.SetField(TIFFTAG_BITSPERSAMPLE, bits)
-                    self.SetField(TIFFTAG_COMPRESSION, COMPRESSION)
+                    self.SetField(TIFFTAG_COMPRESSION, compression)
                     #self.SetField(TIFFTAG_SAMPLESPERPIXEL, 1)
                     self.SetField(TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK)
                     self.SetField(TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT)


### PR DESCRIPTION
Here are a couple of patches that should improve a little the code for the libtiff wrapper. 
(I had send them a while ago by email, but it's probably easier for merging to do it via a pull request).

- The first patch ensures that when compression is None, it's correctly converted to COMPRESSION_NONE for the calls to libtiff.
- The second patch enforces the use of predictor when using compression (and a data type that supports a predictor). That allows a better compression ratio with most data (without changes in the client code).
- The thirds patch is just cosmetic, and removes the use of "exec", which is not recommended to use in Python.