### PR TITLE
ctypes wrapper: fix some method names

### DIFF
--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -908,12 +908,12 @@ class TIFF(ctypes.c_void_p):
     @debug
     def Fileno(self):
         return libtiff.TIFFFileno(self)
-    Fileno = fileno
+    fileno = Fileno
 
     @debug
     def GetMode(self):
         return libtiff.TIFFGetMode(self)
-    GetMode = getmode
+    getmode = GetMode
 
     @debug
     def IsTiled(self):


### PR DESCRIPTION
Previous commit  030e2979, reverting back the method names to CamelCase, was not sufficiently tested. It introduced some typos, which prevented the whole module to load.