### PR TITLE
Extend tile and sub-directory support

### DIFF
--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -707,7 +707,7 @@ class TIFF(ctypes.c_void_p):
             num_irows = 1
         num_icols = self.GetField("ImageWidth")
         if num_icols is None:
-            raise ValueError("TIFFTAG_TILEWIDTH must be set to write tiles")
+            raise ValueError("TIFFTAG_IMAGEWIDTH must be set to write tiles")
         num_idepth = self.GetField("ImageDepth")
         if num_idepth is None:
             num_idepth = 1
@@ -771,8 +771,7 @@ class TIFF(ctypes.c_void_p):
                             tile_arr[0, :] = arr[x:x + num_tcols]
 
                     tile_arr = np.ascontiguousarray(tile_arr)
-                    r = libtiff.TIFFWriteTile(self, tile_arr.ctypes.data, x, y,
-                                              z, 0)
+                    r = self.WriteTile(tile_arr.ctypes.data, x, y, z, 0)
                     status = status + r.value
 
         return status
@@ -780,13 +779,13 @@ class TIFF(ctypes.c_void_p):
     def read_tiles(self, dtype=np.uint8):
         num_tcols = self.GetField("TileWidth")
         if num_tcols is None:
-            raise ValueError("TIFFTAG_TILEWIDTH must be set to write tiles")
+            raise ValueError("TIFFTAG_TILEWIDTH must be set to read tiles")
         num_trows = self.GetField("TileLength")
         if num_trows is None:
             num_trows = 1
         num_icols = self.GetField("ImageWidth")
         if num_icols is None:
-            raise ValueError("TIFFTAG_TILEWIDTH must be set to write tiles")
+            raise ValueError("TIFFTAG_IMAGEWIDTH must be set to read tiles")
         num_irows = self.GetField("ImageLength")
         if num_irows is None:
             num_irows = 1
@@ -810,8 +809,7 @@ class TIFF(ctypes.c_void_p):
         for z in range(0, num_idepth):
             for y in range(0, num_irows, num_trows):
                 for x in range(0, num_icols, num_tcols):
-                    r = libtiff.TIFFReadTile(self, tmp_tile.ctypes.data, x, y,
-                                             z, 0)
+                    r = self.ReadTile(tmp_tile.ctypes.data, x, y, z, 0)
                     if not r:
                         raise ValueError(
                             "Could not read tile x:%d,y:%d,z:%d from file" % (
@@ -906,6 +904,36 @@ class TIFF(ctypes.c_void_p):
     setdirectory = SetDirectory
 
     @debug
+    def SetSubDirectory(self, diroff):
+        """
+        Changes the current directory
+        and reads its contents with TIFFReadDirectory.
+        The parameter dirnum specifies the subfile/directory as
+        an integer number, with the first directory numbered zero.
+
+        SetSubDirectory acts like SetDirectory,
+        except the directory is specified as a file offset instead of an index;
+        this is required for accessing subdirectories
+        linked through a SubIFD tag.
+
+        Parameters
+        ----------
+        diroff: int
+            The offset of the subimage. It's important to notice that
+            it is not an index, like dirnum on SetDirectory
+
+        Returns
+        -------
+        int
+            On successful return 1 is returned.
+            Otherwise, 0 is returned if dirnum or diroff
+            specifies a non-existent directory,
+            or if an error was encountered
+            while reading the directory's contents.
+        """
+        return libtiff.TIFFSetSubDirectory(self, diroff)
+
+    @debug
     def Fileno(self):
         return libtiff.TIFFFileno(self)
     fileno = Fileno
@@ -968,6 +996,70 @@ class TIFF(ctypes.c_void_p):
         r = libtiff.TIFFWriteEncodedStrip(self, strip, buf, size)
         assert r.value == size, repr((r.value, size))
     writeencodedstrip = WriteEncodedStrip
+
+    @debug
+    def ReadTile(self, buf, x, y, z, sample):
+        """ Read and decode a tile of data from an open TIFF file
+
+        Parameters
+        ----------
+        buf: array
+            Content read from the tile.
+            The buffer must be large enough to hold an entire tile of data.
+            Applications should call the routine TIFFTileSize
+            to find out the size (in bytes) of a tile buffer.
+        x: int
+            X coordinate of the upper left pixel of the tile.
+            It must be a multiple of TileWidth.
+        y: int
+            Y coordinate of the upper left pixel of the tile.
+            It must be a multiple of TileLength.
+        z: int
+            It is used if the image is deeper than 1 slice (ImageDepth>1)
+        sample: integer
+            It is used only if data are organized
+            in separate planes (PlanarConfiguration=2)
+
+        Returns
+        -------
+        int
+            -1 if it detects an error;
+            otherwise the number of bytes in the decoded tile is returned.
+        """
+        return libtiff.TIFFReadTile(self, buf, x, y, z, sample)
+
+    @debug
+    def WriteTile(self, buf, x, y, z, sample):
+        """ TIFFWriteTile - encode and write a tile of data to an open TIFF file
+
+        Parameters
+        ----------
+        arr: array
+            Content to be written to the tile.
+            The buffer must be contain an entire tile of data.
+            Applications should call the routine TIFFTileSize
+            to find out the size (in bytes) of a tile buffer.
+        x: int
+            X coordinate of the upper left pixel of the tile.
+            It must be a multiple of TileWidth.
+        y: int
+            Y coordinate of the upper left pixel of the tile.
+            It must be a multiple of TileLength.
+        z: int
+            It is used if the image is deeper than 1 slice (ImageDepth>1)
+        sample: integer
+            It is used only if data are organized
+            in separate planes (PlanarConfiguration=2)
+
+        Returns
+        -------
+        int
+            -1 if it detects an error;
+            otherwise the number of bytes in the tile is returned.
+        """
+        r = libtiff.TIFFWriteTile(self, buf, x, y, z, sample)
+        assert r.value >= 0, repr(r.value)
+        return r
 
     closed = False
 
@@ -1416,6 +1508,9 @@ libtiff.TIFFWriteDirectory.argtypes = [TIFF]
 libtiff.TIFFSetDirectory.restype = ctypes.c_int
 libtiff.TIFFSetDirectory.argtypes = [TIFF, c_tdir_t]
 
+libtiff.TIFFSetSubDirectory.restype = ctypes.c_int
+libtiff.TIFFSetSubDirectory.argtypes = [TIFF, ctypes.c_uint64]
+
 libtiff.TIFFFileno.restype = ctypes.c_int
 libtiff.TIFFFileno.argtypes = [TIFF]
 
@@ -1685,7 +1780,7 @@ def _test_tile_write():
     print("Tile Write: SUCCESS")
 
 
-def _test_tile_read(filename=None):
+def _test_tile_read(filename="/tmp/libtiff_test_tile_write.tiff"):
     import sys
     if filename is None:
         if len(sys.argv) != 2:


### PR DESCRIPTION
We want to be able to read/write "pyramidal images" (as described [here](http://iipimage.sourceforge.net/documentation/images/)). In order to support this format we need two features not provided by the ctypes wrapper: sub-directory access, and access to one tile at a time.

This pull-request addresses these needs. Note that for proper pyramidal images support (and for the test-cases to pass), the PR #57 is also needed.

It's been tested with libtiff 3.95, and 4.0.6, on Ubuntu 32 bits and 64 bits, and Windows 32 bits. 