### PR TITLE
optparse_gui: fix for Python 2

### DIFF
--- a/libtiff/optparse_gui.py
+++ b/libtiff/optparse_gui.py
@@ -15,6 +15,7 @@ Module content
 """
 #Author: Pearu Peterson
 #Created: September 2009
+from __future__ import division, print_function
 
 __all__ = ['OptionParser', 'Option']
 


### PR DESCRIPTION
The update to make it working on Python 3 broke it for Python 2.
Luckily, importing changes from the __future__ fixes it.