### PR TITLE
Fixed tests to pass with python 2.7

### DIFF
--- a/libtiff/bitarray-0.3.5-numpy/bitarray/test_bitarray.py
+++ b/libtiff/bitarray-0.3.5-numpy/bitarray/test_bitarray.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     from __init__ import bitarray, bits2bytes
     repr_type = "<class '__init__.bitarray'>"
 else:
-    from bitarray import bitarray, bits2bytes
+    from libtiff.bitarray import bitarray, bits2bytes
     repr_type = "<class 'bitarray.bitarray'>"
 
 

--- a/libtiff/bitarray-a1646c0/bitarray/__init__.py
+++ b/libtiff/bitarray-a1646c0/bitarray/__init__.py
@@ -8,7 +8,7 @@ Please find a description of this package at:
 
 Author: Ilan Schnell
 """
-from bitarray._bitarray import _bitarray, bitdiff, bits2bytes, _sysinfo
+from ._bitarray import _bitarray, bitdiff, bits2bytes, _sysinfo
 
 __version__ = '0.8.2'
 

--- a/libtiff/bitarray-a1646c0/bitarray/test_bitarray.py
+++ b/libtiff/bitarray-a1646c0/bitarray/test_bitarray.py
@@ -5,7 +5,6 @@ Author: Ilan Schnell
 """
 import os
 import sys
-import unittest
 import tempfile
 import shutil
 from random import randint
@@ -14,9 +13,10 @@ is_py3k = bool(sys.version_info[0] == 3)
 
 if is_py3k:
     from io import StringIO
+    import unittest as ut
 else:
     from io import StringIO
-
+    import unittest2 as ut
 
 from libtiff.bitarray import bitarray, bitdiff, bits2bytes, __version__
 
@@ -24,11 +24,8 @@ from libtiff.bitarray import bitarray, bitdiff, bits2bytes, __version__
 tests = []
 
 if sys.version_info[:2] < (2, 6):
-    is_py_pre_26 = True
     def next(x):
         return x.__next__()
-else:
-    is_py_pre_26 = False
 
 def to_bytes(s):
     if is_py3k:
@@ -39,7 +36,7 @@ def to_bytes(s):
         return s
 
 
-class Util(unittest.TestCase):
+class Util(ut.TestCase):
 
     def randombitarrays(self):
         for n in list(range(25)) + [randint(1000, 2000)]:
@@ -76,11 +73,8 @@ class Util(unittest.TestCase):
     def assertStopIteration(self, it):
         if is_py3k:
             return
-        if is_py_pre_26:
-            self.assertRaises(StopIteration, next(it))
-        else:
-            with self.assertRaises(StopIteration):
-               next(it)
+        with self.assertRaises(StopIteration):
+           next(it)
 
 
 def getIndicesEx(r, length):
@@ -363,7 +357,7 @@ tests.append(ToObjectsTests)
 
 # ---------------------------------------------------------------------------
 
-class MetaDataTests(unittest.TestCase):
+class MetaDataTests(ut.TestCase):
 
     def test_buffer_info1(self):
         a = bitarray('0000111100001', endian='little')
@@ -2020,11 +2014,8 @@ class PrefixCodeTests(Util):
         a = bitarray('1')
         it = a.iterdecode(d)
         if not is_py3k:
-            if is_py_pre_26:
-                self.assertRaises(ValueError, next(it))
-            else:
-                with self.assertRaises(ValueError):
-                    next(it)
+            with self.assertRaises(ValueError):
+                next(it)
         self.assertEqual(a, bitarray('1'))
         self.assertEqual(d, {'a': bitarray('0')})
 
@@ -2039,11 +2030,8 @@ class PrefixCodeTests(Util):
         a = bitarray('1')
         it = a.iterdecode(d)
         if not is_py3k:
-            if is_py_pre_26:
-                self.assrtRaises(ValueError, next(it))
-            else:
-                with self.assertRaises(ValueError):
-                    next(it)
+            with self.assertRaises(ValueError):
+                next(it)
         self.assertEqual(a, bitarray('1'))
 
     def test_decode_ambiguous_code(self):
@@ -2121,7 +2109,7 @@ tests.append(PrefixCodeTests)
 
 # -------------- Buffer Interface (Python 2.7 only for now) ----------------
 
-class BufferInterfaceTests(unittest.TestCase):
+class BufferInterfaceTests(ut.TestCase):
 
     def test_read1(self):
         a = bitarray('01000001' '01000010' '01000011', endian='big')
@@ -2162,12 +2150,12 @@ def run(verbosity=1, repeat=1):
     print(('bitarray version: %s' % __version__))
     print(('Python version: %s' % sys.version))
 
-    suite = unittest.TestSuite()
+    suite = ut.TestSuite()
     for cls in tests:
         for _ in range(repeat):
-            suite.addTest(unittest.makeSuite(cls))
+            suite.addTest(ut.makeSuite(cls))
 
-    runner = unittest.TextTestRunner(verbosity=verbosity)
+    runner = ut.TextTestRunner(verbosity=verbosity)
     return runner.run(suite)
 
 

--- a/libtiff/bitarray-a1646c0/bitarray/test_bitarray.py
+++ b/libtiff/bitarray-a1646c0/bitarray/test_bitarray.py
@@ -8,18 +8,16 @@ import sys
 import tempfile
 import shutil
 from random import randint
+from io import StringIO
 
 is_py3k = bool(sys.version_info[0] == 3)
 
-if is_py3k:
-    from io import StringIO
+if sys.version_info[:2] > (2, 6):
     import unittest as ut
 else:
-    from io import StringIO
     import unittest2 as ut
 
 from libtiff.bitarray import bitarray, bitdiff, bits2bytes, __version__
-
 
 tests = []
 

--- a/libtiff/bitarray-a1646c0/bitarray/test_bitarray.py
+++ b/libtiff/bitarray-a1646c0/bitarray/test_bitarray.py
@@ -18,15 +18,17 @@ else:
     from io import StringIO
 
 
-from bitarray import bitarray, bitdiff, bits2bytes, __version__
+from libtiff.bitarray import bitarray, bitdiff, bits2bytes, __version__
 
 
 tests = []
 
 if sys.version_info[:2] < (2, 6):
+    is_py_pre_26 = True
     def next(x):
         return x.__next__()
-
+else:
+    is_py_pre_26 = False
 
 def to_bytes(s):
     if is_py3k:
@@ -37,7 +39,7 @@ def to_bytes(s):
         return s
 
 
-class Util(object):
+class Util(unittest.TestCase):
 
     def randombitarrays(self):
         for n in list(range(25)) + [randint(1000, 2000)]:
@@ -60,7 +62,7 @@ class Util(object):
         return getIndicesEx(r, length)[-1]
 
     def check_obj(self, a):
-        self.assertEqual(repr(type(a)), "<class 'bitarray.bitarray'>")
+        self.assertEqual(repr(type(a)), "<class 'libtiff.bitarray.bitarray'>")
         unused = 8 * a.buffer_info()[1] - len(a)
         self.assertTrue(0 <= unused < 8)
         self.assertEqual(unused, a.buffer_info()[3])
@@ -74,7 +76,11 @@ class Util(object):
     def assertStopIteration(self, it):
         if is_py3k:
             return
-        self.assertRaises(StopIteration, it.__next__)
+        if is_py_pre_26:
+            self.assertRaises(StopIteration, next(it))
+        else:
+            with self.assertRaises(StopIteration):
+               next(it)
 
 
 def getIndicesEx(r, length):
@@ -124,7 +130,7 @@ def getIndicesEx(r, length):
 
 # ---------------------------------------------------------------------------
 
-class TestsModuleFunctions(unittest.TestCase, Util):
+class TestsModuleFunctions(Util):
 
     def test_bitdiff(self):
         a = bitarray('0011')
@@ -173,7 +179,7 @@ tests.append(TestsModuleFunctions)
 
 # ---------------------------------------------------------------------------
 
-class CreateObjectTests(unittest.TestCase, Util):
+class CreateObjectTests(Util):
 
     def test_noInitializer(self):
         a = bitarray()
@@ -328,7 +334,7 @@ tests.append(CreateObjectTests)
 
 # ---------------------------------------------------------------------------
 
-class ToObjectsTests(unittest.TestCase, Util):
+class ToObjectsTests(Util):
 
     def test_int(self):
         a = bitarray()
@@ -412,7 +418,7 @@ tests.append(MetaDataTests)
 
 # ---------------------------------------------------------------------------
 
-class SliceTests(unittest.TestCase, Util):
+class SliceTests(Util):
 
     def test_getitem1(self):
         a = bitarray()
@@ -593,7 +599,7 @@ tests.append(SliceTests)
 
 # ---------------------------------------------------------------------------
 
-class MiscTests(unittest.TestCase, Util):
+class MiscTests(Util):
 
     def test_instancecheck(self):
         a = bitarray('011')
@@ -754,7 +760,7 @@ tests.append(MiscTests)
 
 # ---------------------------------------------------------------------------
 
-class SpecialMethodTests(unittest.TestCase, Util):
+class SpecialMethodTests(Util):
 
     def test_all(self):
         a = bitarray()
@@ -850,7 +856,7 @@ tests.append(SpecialMethodTests)
 
 # ---------------------------------------------------------------------------
 
-class NumberTests(unittest.TestCase, Util):
+class NumberTests(Util):
 
     def test_add(self):
         c = bitarray('001') + bitarray('110')
@@ -945,7 +951,7 @@ tests.append(NumberTests)
 
 # ---------------------------------------------------------------------------
 
-class BitwiseTests(unittest.TestCase, Util):
+class BitwiseTests(Util):
 
     def test_misc(self):
         for a in self.randombitarrays():
@@ -1032,7 +1038,7 @@ tests.append(BitwiseTests)
 
 # ---------------------------------------------------------------------------
 
-class SequenceTests(unittest.TestCase, Util):
+class SequenceTests(Util):
 
     def test_contains1(self):
         a = bitarray()
@@ -1093,7 +1099,7 @@ tests.append(SequenceTests)
 
 # ---------------------------------------------------------------------------
 
-class ExtendTests(unittest.TestCase, Util):
+class ExtendTests(Util):
 
     def test_wrongArgs(self):
         a = bitarray()
@@ -1216,7 +1222,7 @@ tests.append(ExtendTests)
 
 # ---------------------------------------------------------------------------
 
-class MethodTests(unittest.TestCase, Util):
+class MethodTests(Util):
 
     def test_append(self):
         a = bitarray()
@@ -1582,7 +1588,7 @@ tests.append(MethodTests)
 
 # ---------------------------------------------------------------------------
 
-class StringTests(unittest.TestCase, Util):
+class StringTests(Util):
 
     def randombytes(self):
         for n in range(1, 20):
@@ -1695,7 +1701,7 @@ tests.append(StringTests)
 
 # ---------------------------------------------------------------------------
 
-class FileTests(unittest.TestCase, Util):
+class FileTests(Util):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -1903,7 +1909,7 @@ tests.append(FileTests)
 
 # ---------------------------------------------------------------------------
 
-class PrefixCodeTests(unittest.TestCase, Util):
+class PrefixCodeTests(Util):
 
     def test_encode_errors(self):
         a = bitarray()
@@ -2014,7 +2020,11 @@ class PrefixCodeTests(unittest.TestCase, Util):
         a = bitarray('1')
         it = a.iterdecode(d)
         if not is_py3k:
-            self.assertRaises(ValueError, it.__next__)
+            if is_py_pre_26:
+                self.assertRaises(ValueError, next(it))
+            else:
+                with self.assertRaises(ValueError):
+                    next(it)
         self.assertEqual(a, bitarray('1'))
         self.assertEqual(d, {'a': bitarray('0')})
 
@@ -2029,7 +2039,11 @@ class PrefixCodeTests(unittest.TestCase, Util):
         a = bitarray('1')
         it = a.iterdecode(d)
         if not is_py3k:
-            self.assertRaises(ValueError, it.__next__)
+            if is_py_pre_26:
+                self.assrtRaises(ValueError, next(it))
+            else:
+                with self.assertRaises(ValueError):
+                    next(it)
         self.assertEqual(a, bitarray('1'))
 
     def test_decode_ambiguous_code(self):

--- a/libtiff/setup.py
+++ b/libtiff/setup.py
@@ -81,7 +81,7 @@ if %(d)r not in sys.path:
                 f = open(target, 'w')
                 f.write(new_text)
                 f.close()
-            print("*****{}".format(target_name))
+            print("*****{0}".format(target_name))
         config.add_scripts(generate_a_script)
         
 


### PR DESCRIPTION
1. Change importing of bitarray in ``bitarray/__init__.py`` to use relative path
2. Replaced remaining explicit uses of ``it.__next__`` with uses of ``next(it)``
3. For py2.7 use with ``self.assertRaises(errclass): statement`` rather than
   ``self.assertRaises(errclass, statement)``

   py26 still uses the older formulation.