### PR TITLE
ARM64: Add ARM64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,31 +2,52 @@ language: python
 python:
   - 2.7
   - 3.6
-
+arch:
+  - amd64
+  - arm64
 before_install:
-  - sudo apt-get install -y git wget
-
+  - sudo apt-get install -y git wget libtiff-dev
+env:
+  global:
+    - SUDO=""
 install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+      wget -q "https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh" -O archiconda.sh;
+      chmod +x archiconda.sh;
+      bash archiconda.sh -b -p $HOME/miniconda;
+      SUDO=sudo;
+      $SUDO cp -r $HOME/miniconda/bin/* /usr/bin/;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+        bash miniconda.sh -b -p $HOME/miniconda;
+      else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        bash miniconda.sh -b -p $HOME/miniconda;
+      fi
     fi
   - export MINICONDA=$HOME/miniconda
-  - bash miniconda.sh -b -p $HOME/miniconda
   - hash -r
   - source $MINICONDA/etc/profile.d/conda.sh
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update --quiet --yes conda
-  - conda info -a
-  - conda env create --quiet --name pylibtiff-dev --file .conda/environment.yml
+  - $SUDO conda config --set always_yes yes --set changeps1 no
+  - $SUDO chmod -R 777 $HOME/miniconda/*
+  - $SUDO conda update --quiet --yes conda
+  - $SUDO conda info -a
+  - $SUDO conda env create --quiet --name pylibtiff-dev --file .conda/environment.yml
   - conda activate pylibtiff-dev
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      conda install --yes --quiet python=2.7 -c conda-forge;
+      $SUDO conda install --yes --quiet python=2.7 -c conda-forge;
     fi
   - export PREFIX=$CONDA_PREFIX
 
 before_script:
+  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+     if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+       sudo chmod -R 777 $HOME/miniconda/envs/pylibtiff-dev/lib/python2.7/site-packages;
+     else
+       sudo chmod -R 777 $HOME/miniconda/envs/pylibtiff-dev/lib/python3.*/site-packages;
+     fi
+    fi
   - python setup.py develop
 
 script:


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 jobs in Travis-CI. Installed conda packages using archiconda.