### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 arch:
   - amd64
   - arm64
+  - ppc64le
 before_install:
   - sudo apt-get install -y git wget libtiff-dev
 env:
@@ -17,6 +18,10 @@ install:
       bash archiconda.sh -b -p $HOME/miniconda;
       SUDO=sudo;
       $SUDO cp -r $HOME/miniconda/bin/* /usr/bin/;
+    fi
+  - if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then 
+      wget https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-ppc64le.sh -O miniconda.sh;
+      bash miniconda.sh -b -p $HOME/miniconda;
     else
       if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Pls verify and merge

