### PR TITLE
Ignore deprecation defines added in tiff 4.3 headers.

### DIFF
--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -114,6 +114,8 @@ if tiff_h is None:
         if len(words) != 2:
             continue
         name, value = words
+        if name in ['TIFF_GCC_DEPRECATED', 'TIFF_MSC_DEPRECATED']:
+            continue
         i = value.find('/*')
         if i != -1:
             value = value[:i]


### PR DESCRIPTION
Without this fix the following error occurs:

```
('__attribute__((deprecated))', '#define TIFF_GCC_DEPRECATED __attribute__((deprecated))\n') name '__attribute__' is not defined
Traceback (most recent call last):
  File "/home/bob/git/pylibtiff/./test.py", line 3, in <module>
    import libtiff
  File "/home/bob/git/pylibtiff/libtiff/__init__.py", line 23, in <module>
    from .libtiff_ctypes import libtiff, TIFF, TIFF3D  # noqa: F401
  File "/home/bob/git/pylibtiff/libtiff/libtiff_ctypes.py", line 127, in <module>
    value = eval(value)
  File "<string>", line 1, in <module>
NameError: name '__attribute__' is not defined
```