### PR TITLE
libtiff_ctypes: search first for libtiff.dll before libtiff3.dll

### DIFF
--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -23,10 +23,11 @@ cwd = os.getcwd()
 try:
     os.chdir(os.path.dirname(__file__))
     if os.name == 'nt':
-        # assume that the directory of libtiff3.dll is in PATH.
-        lib = ctypes.util.find_library('libtiff3')
+        # assume that the directory of libtiff.dll is in PATH.
+        lib = ctypes.util.find_library('libtiff.dll')
         if lib is None:
-            lib = ctypes.util.find_library('libtiff.dll')
+            # Fallback to the old "libtiff3" name
+            lib = ctypes.util.find_library('libtiff3')
         if lib is None:
             # try default installation path:
             lib = r'C:\Program Files\GnuWin32\bin\libtiff3.dll'


### PR DESCRIPTION
Some time ago, the GnuWin32 project provided Windows builds of libtiff, under the filename libtiff3.dll. The last version was 3.8.2, in 2006. The more recent versions of libtiff (v4+) are built as libtiff.dll.

Some customers were not able to run our application, although we ship the latest version of libtiff.dll with it. It turned out that they have an old 32-bit version of libtiff3.dll somewhere else on their system. This made LoadLibrary fail with such (confusing) error message: "Failed to load dynlib/dll 'C:\\GTK\\bin\\libtiff3.dll'. Most probably this dynlib/dll was not found when the application was frozen."

=> Change the order of DLL search to first look for the recent version, and fallback to the ancient libtiff3.

