### PR TITLE
Fix compatibility with newer numpy (np.bool_)

### DIFF
--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -641,7 +641,7 @@ class TIFF(ctypes.c_void_p):
         arr = np.ascontiguousarray(arr)
         if arr.dtype in np.sctypes['float']:
             sample_format = SAMPLEFORMAT_IEEEFP
-        elif arr.dtype in np.sctypes['uint'] + [np.bool]:
+        elif arr.dtype in np.sctypes['uint'] + [np.bool_]:
             sample_format = SAMPLEFORMAT_UINT
         elif arr.dtype in np.sctypes['int']:
             sample_format = SAMPLEFORMAT_INT
@@ -728,7 +728,7 @@ class TIFF(ctypes.c_void_p):
 
         if arr.dtype in np.sctypes['float']:
             sample_format = SAMPLEFORMAT_IEEEFP
-        elif arr.dtype in np.sctypes['uint'] + [np.bool]:
+        elif arr.dtype in np.sctypes['uint'] + [np.bool_]:
             sample_format = SAMPLEFORMAT_UINT
         elif arr.dtype in np.sctypes['int']:
             sample_format = SAMPLEFORMAT_INT


### PR DESCRIPTION
Closes #134. `numpy.bool` is being deprecated in numpy and will result in an AttributeError if used from now on. This PR replaces the usage with `np.bool_` which is supported and seems to work.

CC @mraspaud @gerritholl @talonglong