### PR TITLE
Add missing README.md to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE
-include README.txt
+include README.md


### PR DESCRIPTION
The conda-forge build revealed that the sdist was missing the README.md file so `setup.py` was failing.