### PR TITLE
Update to new setuptools_scm and remove deprecated setuptools_scm_git_archive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2", 'setuptools_scm_git_archive', 'oldest-supported-numpy']
+requires = ["setuptools>=60", "wheel", "setuptools_scm[toml]>=8.0", 'oldest-supported-numpy']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
setuptools_scm_git_archive has been deprecated for a long time. The new version of setuptools_scm (8+) makes incompatible changes that break building for all packages using the deprecated git archive package. This updates pylibtiff to use the new versions of stuff.