### PR TITLE
Change matplotlib backend to GTk3Agg for POSIX

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,6 @@ jobs:
           --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple/ \
           --trusted-host pypi.anaconda.org \
           --no-deps --pre --upgrade \
-          matplotlib \
           numpy;
           LD_PRELOAD=$(python -c "import sys; print(sys.prefix)")/lib/libstdc++.so
           echo "LD_PRELOAD=${LD_PRELOAD}" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ LSM files, it is as fast as libtiff.py by using numpy.
 # Script usage examples #
 
 ```
-$ libtiff.info -i result_0.tif --no-gui
+$ libtiff.info -i result_0.tif
 IFDEntry(tag=ImageWidth, value=512, count=1, offset=None)
 IFDEntry(tag=ImageLength, value=512, count=1, offset=None)
 IFDEntry(tag=BitsPerSample, value=32, count=1, offset=None)
@@ -92,7 +92,7 @@ strip_length : 1048576
 ```
 
 ```
-$ libtiff.info --no-gui -i psf_1024_z5_airy1_set1.lsm
+$ libtiff.info -i psf_1024_z5_airy1_set1.lsm
 IFDEntry(tag=NewSubfileType, value=0, count=1, offset=None)
 IFDEntry(tag=ImageWidth, value=1024, count=1, offset=None)
 IFDEntry(tag=ImageLength, value=1024, count=1, offset=None)

--- a/libtiff/script_options.py
+++ b/libtiff/script_options.py
@@ -1,8 +1,5 @@
-
-
 __all__ = ['set_formatter', 'set_info_options', 'set_convert_options']
 
-import os
 from optparse import NO_DEFAULT
 from optparse import TitledHelpFormatter
 

--- a/libtiff/script_options.py
+++ b/libtiff/script_options.py
@@ -63,7 +63,7 @@ def set_convert_options(parser):
     if os.name == 'posix':
         try:
             import matplotlib
-            matplotlib.use('GTkAgg')
+            matplotlib.use('GTk3Agg')
             parser.run_methods = ['subcommand']
         except ImportError:
             pass
@@ -92,7 +92,7 @@ def set_info_options(parser):
     if os.name == 'posix':
         try:
             import matplotlib
-            matplotlib.use('GTkAgg')
+            matplotlib.use('GTk3Agg')
             parser.run_methods = ['subcommand']
         except ImportError:
             pass

--- a/libtiff/script_options.py
+++ b/libtiff/script_options.py
@@ -6,12 +6,6 @@ import os
 from optparse import NO_DEFAULT
 from optparse import TitledHelpFormatter
 
-try:
-    import wx  # noqa: F401
-    have_wx = True
-except ImportError:
-    have_wx = False
-
 
 class MyHelpFormatter(TitledHelpFormatter):
 
@@ -60,20 +54,13 @@ def set_formatter(parser):
 
 def set_convert_options(parser):
     set_formatter(parser)
-    if os.name == 'posix':
-        try:
-            import matplotlib
-            matplotlib.use('GTk3Agg')
-            parser.run_methods = ['subcommand']
-        except ImportError:
-            pass
     parser.set_usage('%prog [options] -i INPUTPATH [-o OUTPUTPATH]')
     parser.set_description('Convert INPUTPATH to OUTPUTPATH.')
     parser.add_option('--input-path', '-i',
-                      type='file' if have_wx else str, metavar='INPUTPATH',
+                      type=str, metavar='INPUTPATH',
                       help='Specify INPUTPATH.')
     parser.add_option('--output-path', '-o',
-                      type='file' if have_wx else str, metavar='OUTPUTPATH',
+                      type=str, metavar='OUTPUTPATH',
                       help='Specify OUTPUTPATH.')
     parser.add_option('--compression',
                       type='choice', default='none',
@@ -89,17 +76,10 @@ def set_convert_options(parser):
 
 def set_info_options(parser):
     set_formatter(parser)
-    if os.name == 'posix':
-        try:
-            import matplotlib
-            matplotlib.use('GTk3Agg')
-            parser.run_methods = ['subcommand']
-        except ImportError:
-            pass
     parser.set_usage('%prog [options] -i INPUTPATH')
     parser.set_description('Show INPUTPATHs information.')
     parser.add_option('--input-path', '-i',
-                      type='file' if have_wx else str, metavar='INPUTPATH',
+                      type=str, metavar='INPUTPATH',
                       help='Specify INPUTPATH.')
     parser.add_option('--memory-usage',
                       action='store_true', default=False,


### PR DESCRIPTION
Replaces #164. This also drops a `wx` import in addition to dropping the `matplotlib` import we talked about in #164. @pearu thoughts?

CC @dennis-johnson