### PR TITLE
ctypes: don't fail to load when embedded as a "frozen" package

### DIFF
--- a/libtiff/libtiff_ctypes.py
+++ b/libtiff/libtiff_ctypes.py
@@ -23,7 +23,15 @@ __all__ = ['libtiff', 'TIFF']
 
 cwd = os.getcwd()
 try:
-    os.chdir(os.path.dirname(__file__))
+    try:
+        # Typically, on Windows, the CWD is among the folders searched to locate
+        # a DLL. So change it to the directory containing this module, in case
+        # the libtiff DLL was installed aside it (although that's not typically the case).
+        os.chdir(os.path.dirname(__file__))
+    except FileNotFoundError:
+        # If "frozen" (ie, embedded in an executable), the directory is not real, and chdir fails
+        # => just ignore (and look for the DLL in all the other standard locations)
+        pass
     if os.name == 'nt':
         # assume that the directory of the libtiff DLL is in PATH.
         for lib in ('tiff', 'libtiff', 'libtiff3'):

--- a/libtiff/lsm.py
+++ b/libtiff/lsm.py
@@ -34,7 +34,6 @@ def IFDEntry_lsm_str_hook(entry):
 def IFDEntry_lsm_init_hook(ifdentry):
     """Make tiff.IFDENTRYEntry CZ_LSM aware.
     """
-    global tiff_module_dict
     if ifdentry.tag == CZ_LSMInfo_tag:
         # replace type,count=(BYTE,500) with (CZ_LSMInfo, 1)
         reserved_bytes = (ifdentry.count - CZ_LSMInfo_dtype_fields_size)


### PR DESCRIPTION
When the module is embedded in a executable (aka "frozen"), the __file__ path is virtual, and might not actually exists on the computer. This path is used at init to look for the DLL, by changing the current working directory to the containing folder. As it doesn't exist, it fails, and libtiff_ctypes cannot be imported.

Instead of completely failing, now handle such case, and just don't use that folder as an extra location to look for the DLL.